### PR TITLE
Replace the hand-maintained JSON Schema (Draft 2020-12) with the offi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ v.AddDialog(vcon.Dialog{
 })
 ```
 
-Dialog types: `"recording"`, `"text"`, `"transfer"`, `"incomplete"`, `"email"`, `"conference"`.
+Dialog types: `"recording"`, `"text"`, `"transfer"`, `"incomplete"`.
 
 Valid encodings: `"base64url"`, `"json"`, `"none"`.
 
@@ -262,7 +262,7 @@ Track participants joining, leaving, or being placed on hold during a dialog:
 
 ```go
 v.AddDialog(vcon.Dialog{
-    Type:      "conference",
+    Type:      "recording",
     StartTime: &startTime,
     Duration:  900.0,
     Parties:   []int{0, 1, 2},
@@ -310,7 +310,7 @@ Attachments are supplementary files associated with specific parties and time ra
 
 ```go
 v.AddAttachment(vcon.Attachment{
-    DialogIdx: 0,
+    DialogIdx: vcon.IntPtr(0),
     PartyIdx:  1,
     StartTime: time.Now().UTC(),
     MediaType: "application/pdf",

--- a/cmd/vconctl/convert_email.go
+++ b/cmd/vconctl/convert_email.go
@@ -76,12 +76,13 @@ func runEmail(_ *cobra.Command, args []string) error {
 	}
 
 	v.Dialog = append(v.Dialog, vcon.Dialog{
-		Type:      "email",
-		StartTime: &v.CreatedAt,
-		Parties:   dialogParties,
-		Body:      env.Text,
-		MediaType: "text/plain",
-		MessageID: env.GetHeader("Message-Id"),
+		Type:        "text",
+		Application: "email",
+		StartTime:   &v.CreatedAt,
+		Parties:     dialogParties,
+		Body:        env.Text,
+		MediaType:   "text/plain",
+		MessageID:   env.GetHeader("Message-Id"),
 	})
 
 	return writeVconFile(v, vConOut, f)

--- a/cmd/vconctl/convert_email_test.go
+++ b/cmd/vconctl/convert_email_test.go
@@ -178,7 +178,8 @@ func TestRunEmailIntegration(t *testing.T) {
 
 	// Check for email-specific content
 	emailSpecificStrings := []string{
-		"\"type\": \"email\"",
+		"\"type\": \"text\"",
+		"\"application\": \"email\"",
 		"\"mediatype\": \"text/plain\"",
 		"mailto:",
 	}

--- a/cmd/vconctl/convert_zoom.go
+++ b/cmd/vconctl/convert_zoom.go
@@ -67,6 +67,9 @@ func runZoom(_ *cobra.Command, args []string) error {
 			Filename:  f.Name,
 			URL:       f.Path,
 			MediaType: f.Type,
+			DialogIdx: vcon.IntPtr(0),
+			PartyIdx:  0,
+			StartTime: meta.Start,
 		}
 		v.Attachments = append(v.Attachments, att)
 	}

--- a/pkg/vcon/attachment.go
+++ b/pkg/vcon/attachment.go
@@ -28,12 +28,17 @@ type Attachment struct {
 	Encoding    string          `json:"encoding,omitempty"`
 	URL         string          `json:"url,omitempty"`
 	ContentHash ContentHashList `json:"content_hash,omitempty"`
-	DialogIdx   int             `json:"dialog,omitempty"`
+	DialogIdx   *int            `json:"dialog"`
 	PartyIdx    int             `json:"party"`
 	StartTime   time.Time       `json:"start"`
 	MediaType   string          `json:"mediatype,omitempty"`
 	Filename    string          `json:"filename,omitempty"`
 	Purpose     string          `json:"purpose,omitempty"`
+}
+
+// IntPtr returns a pointer to the given int value.
+func IntPtr(v int) *int {
+	return &v
 }
 
 // NewAttachment creates a new Attachment with the specified type, body, and encoding

--- a/pkg/vcon/attachment_test.go
+++ b/pkg/vcon/attachment_test.go
@@ -130,7 +130,7 @@ func TestAttachmentSerialization(t *testing.T) {
 	attachment := Attachment{
 		Body:        "test content",
 		Encoding:    "none",
-		DialogIdx:   1,
+		DialogIdx:   IntPtr(1),
 		PartyIdx:    0,
 		StartTime:   startTime,
 		MediaType:   "text/plain",
@@ -159,8 +159,8 @@ func TestAttachmentSerialization(t *testing.T) {
 		t.Errorf("expected encoding %s, got %s", attachment.Encoding, unmarshaled.Encoding)
 	}
 
-	if unmarshaled.DialogIdx != attachment.DialogIdx {
-		t.Errorf("expected dialog index %d, got %d", attachment.DialogIdx, unmarshaled.DialogIdx)
+	if unmarshaled.DialogIdx == nil || *unmarshaled.DialogIdx != *attachment.DialogIdx {
+		t.Errorf("expected dialog index %v, got %v", attachment.DialogIdx, unmarshaled.DialogIdx)
 	}
 
 	if unmarshaled.PartyIdx != attachment.PartyIdx {
@@ -185,7 +185,7 @@ func TestAttachmentWithURL(t *testing.T) {
 
 	attachment := Attachment{
 		URL:         "https://example.com/document.pdf",
-		DialogIdx:   0,
+		DialogIdx:   IntPtr(0),
 		PartyIdx:    1,
 		StartTime:   startTime,
 		MediaType:   "application/pdf",
@@ -218,9 +218,10 @@ func TestAttachmentWithURL(t *testing.T) {
 func TestAttachmentOmitEmpty(t *testing.T) {
 	startTime := time.Date(2023, 1, 15, 10, 30, 0, 0, time.UTC)
 
-	// Minimal attachment with only required fields
+	// Minimal attachment with required fields (dialog is now required by IETF schema)
 	attachment := Attachment{
 		PartyIdx:  0,
+		DialogIdx: IntPtr(0),
 		StartTime: startTime,
 	}
 
@@ -236,13 +237,17 @@ func TestAttachmentOmitEmpty(t *testing.T) {
 		t.Error("expected party index to be present")
 	}
 
+	if !strings.Contains(jsonStr, `"dialog":0`) {
+		t.Error("expected dialog index to be present")
+	}
+
 	if !strings.Contains(jsonStr, `"start":`) {
 		t.Error("expected start time to be present")
 	}
 
 	// Optional fields should be omitted when empty
 	unwantedFields := []string{
-		"body", "encoding", "url", "content_hash", "dialog",
+		"body", "encoding", "url", "content_hash",
 		"mediatype", "filename", "purpose",
 	}
 
@@ -318,5 +323,28 @@ func TestAttachmentEncodingValidation(t *testing.T) {
 				t.Errorf("expected invalid encoding %s to fail", encoding)
 			}
 		})
+	}
+}
+
+func TestAttachmentDialogRequired(t *testing.T) {
+	// Attachment missing "dialog" should fail schema validation via BuildFromJSON
+	jsonStr := `{
+		"vcon": "0.4.0",
+		"uuid": "550e8400-e29b-41d4-a716-446655440000",
+		"created_at": "2023-01-15T10:30:00Z",
+		"parties": [{"name": "Alice"}],
+		"dialog": [{"type": "recording", "start": "2023-01-15T10:30:00Z"}],
+		"attachments": [
+			{
+				"body": "data",
+				"encoding": "none",
+				"party": 0,
+				"start": "2023-01-15T10:30:00Z"
+			}
+		]
+	}`
+	_, err := BuildFromJSON(jsonStr)
+	if err == nil {
+		t.Error("expected error for attachment missing required 'dialog' field")
 	}
 }

--- a/pkg/vcon/complex_vcon_test.go
+++ b/pkg/vcon/complex_vcon_test.go
@@ -89,7 +89,7 @@ func TestValidComplexVCon(t *testing.T) {
 
 	// Add an attachment related to the initial call
 	attachmentIdx := v.AddAttachment(vcon.Attachment{
-		DialogIdx: initialCallIdx,
+		DialogIdx: vcon.IntPtr(initialCallIdx),
 		PartyIdx:  agentIdx,
 		StartTime: now,
 		MediaType: "application/pdf",
@@ -135,7 +135,7 @@ func TestValidComplexVCon(t *testing.T) {
 	ttVal, ok := v.Dialog[transferDialogIdx].TargetDialog.AsInt()
 	assert.True(t, ok)
 	assert.Equal(t, initialCallIdx, ttVal, "Transfer should reference initial call")
-	assert.Equal(t, initialCallIdx, v.Attachments[attachmentIdx].DialogIdx, "Attachment should reference initial call")
+	assert.Equal(t, initialCallIdx, *v.Attachments[attachmentIdx].DialogIdx, "Attachment should reference initial call")
 	assert.Equal(t, []int{initialCallIdx, followupDialogIdx}, v.Analysis[transcriptIdx].Dialog, "Transcript should reference both calls")
 
 	// Verify sentiment analysis properties
@@ -197,6 +197,7 @@ func TestInvalidDialogReference(t *testing.T) {
 
 	v.AddAnalysis(vcon.Analysis{
 		Type:   "transcript",
+		Vendor: "TestVendor",
 		Dialog: []int{dialogIdx, 10}, // 10 is an invalid dialog index
 	})
 
@@ -272,7 +273,7 @@ func TestComplexConferenceScenario(t *testing.T) {
 	endTime := startTime.Add(15 * time.Minute)
 
 	conferenceIdx := v.AddDialog(vcon.Dialog{
-		Type:       "conference",
+		Type:       "recording", // Schema restricts to: recording, text, transfer, incomplete
 		StartTime:  &startTime,
 		Duration:   (endTime.Sub(startTime)).Seconds(),
 		Parties:    []int{moderatorIdx, participant1Idx, participant2Idx, participant3Idx},

--- a/pkg/vcon/dialog_test.go
+++ b/pkg/vcon/dialog_test.go
@@ -16,9 +16,13 @@ func TestDialogTypes(t *testing.T) {
 		{"text", true},
 		{"transfer", true},
 		{"incomplete", true},
+		// Note: The IETF schema restricts dialog type to the enum
+		// [recording, text, transfer, incomplete]. The following types
+		// are valid at the Go struct level but will fail schema validation
+		// via BuildFromJSON.
 		{"email", true},
 		{"chat", true},
-		{"invalid_type", true}, // Any string is valid for dialog type
+		{"invalid_type", true},
 	}
 
 	for _, tt := range tests {
@@ -254,7 +258,7 @@ func TestDialogWithPartyHistory(t *testing.T) {
 	}
 
 	dialog := Dialog{
-		Type:         "conference",
+		Type:         "recording", // Schema restricts to: recording, text, transfer, incomplete
 		StartTime:    &startTime,
 		Duration:     65.0,
 		Parties:      []int{0, 1},

--- a/pkg/vcon/schema/vcon.json
+++ b/pkg/vcon/schema/vcon.json
@@ -1,448 +1,508 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://ietf.org/vcon/schemas/unsigned-vcon.json",
-  "title": "vCon JSON Container (draft-ietf-vcon-vcon-core-02)",
+  "title": "vCon - Unsigned Form",
+  "description": "JSON schema for the unsigned form of vCon (Conversational Data Container) as defined in draft-ietf-vcon-vcon-core-01, sections 1-4",
   "type": "object",
-  "required": [
-    "uuid",
-    "created_at",
-    "parties"
-  ],
+  "required": ["uuid", "created_at", "parties"],
   "properties": {
     "vcon": {
       "type": "string",
-      "const": "0.4.0",
-      "description": "Deprecated version identifier for this vCon draft"
+      "description": "DEPRECATED: Syntactic version of the JSON format. For this document, must be '0.4.0'",
+      "const": "0.4.0"
     },
     "uuid": {
       "type": "string",
+      "description": "Globally unique identifier for the vCon. SHOULD be a version 8 UUID",
       "format": "uuid"
+    },
+    "extensions": {
+      "type": "array",
+      "description": "List of names of all vCon extensions for any parameters not defined in the core schema",
+      "items": {
+        "type": "string"
+      }
+    },
+    "critical": {
+      "type": "array",
+      "description": "List of extension names that are incompatible with the core vCon schema and require explicit support",
+      "items": {
+        "type": "string"
+      }
     },
     "created_at": {
       "type": "string",
+      "description": "Creation time of this vCon in RFC3339 format",
       "format": "date-time"
     },
     "updated_at": {
       "type": "string",
+      "description": "Last modified time of this vCon in RFC3339 format",
       "format": "date-time"
     },
     "subject": {
-      "type": "string"
-    },
-    "extensions": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "Extension name tokens used in this vCon"
-    },
-    "critical": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "Incompatible extension tokens that MUST be understood"
+      "type": "string",
+      "description": "Subject or topic of the conversation"
     },
     "redacted": {
       "type": "object",
+      "description": "Reference to the unredacted or less redacted vCon instance version",
+      "required": ["uuid", "type"],
       "properties": {
         "uuid": {
           "type": "string",
+          "description": "UUID of the unredacted/prior vCon instance version",
           "format": "uuid"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of redaction performed"
         },
         "url": {
           "type": "string",
+          "description": "HTTPS URL where the referenced vCon is stored",
           "format": "uri"
         },
         "content_hash": {
-          "$ref": "#/$defs/content_hash_value"
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ],
+          "description": "Hash(es) of the external content using format: algorithm-base64url_encoded_hash"
         }
-      },
-      "required": ["uuid", "type"]
+      }
     },
     "amended": {
       "type": "object",
+      "description": "Reference to the prior vCon instance version that this vCon amends",
       "properties": {
         "uuid": {
           "type": "string",
+          "description": "UUID of the prior vCon instance version",
           "format": "uuid"
         },
         "url": {
           "type": "string",
+          "description": "HTTPS URL where the referenced vCon is stored",
           "format": "uri"
         },
         "content_hash": {
-          "$ref": "#/$defs/content_hash_value"
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ],
+          "description": "Hash(es) of the external content (required if url is provided)"
         }
       }
     },
     "group": {
       "type": "array",
-      "items": {}
+      "description": "Array of related vCons that aggregate into this conversation",
+      "items": {
+        "type": "object",
+        "description": "Group Object - details not fully specified in sections 1-4"
+      }
     },
     "parties": {
       "type": "array",
+      "description": "Array of Party Objects representing all parties involved in the conversation",
       "items": {
-        "$ref": "#/$defs/party"
+        "$ref": "#/definitions/Party"
       }
     },
     "dialog": {
       "type": "array",
+      "description": "Array of Dialog Objects containing the captured conversation content",
       "items": {
-        "$ref": "#/$defs/dialog"
+        "$ref": "#/definitions/Dialog"
       }
     },
     "analysis": {
       "type": "array",
+      "description": "Array of Analysis Objects containing analysis performed on the conversational data",
       "items": {
-        "$ref": "#/$defs/analysis"
+        "$ref": "#/definitions/Analysis"
       }
     },
     "attachments": {
       "type": "array",
+      "description": "Array of Attachment Objects for ancillary documents related to the conversation",
       "items": {
-        "$ref": "#/$defs/attachment"
+        "$ref": "#/definitions/Attachment"
       }
     }
   },
-  "$defs": {
-    "content_hash_value": {
-      "description": "Content hash in format 'algorithm-base64url_hash' — single string or array",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "int_or_array": {
-      "description": "Single integer or array of integers",
-      "oneOf": [
-        {
-          "type": "integer",
-          "minimum": 0
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 0
-          }
-        }
-      ]
-    },
-    "party": {
+  "definitions": {
+    "Party": {
       "type": "object",
+      "description": "Represents a party involved in the conversation",
       "properties": {
         "tel": {
-          "type": "string"
-        },
-        "stir": {
-          "type": "string"
-        },
-        "mailto": {
-          "type": "string"
+          "type": "string",
+          "description": "TEL URL (RFC3966) for the party"
         },
         "sip": {
-          "type": "string"
+          "type": "string",
+          "description": "SIP URL for the party"
         },
-        "did": {
-          "type": "string"
+        "stir": {
+          "type": "string",
+          "description": "STIR PASSporT in JWS Compact Serialization form"
+        },
+        "mailto": {
+          "type": "string",
+          "description": "MAILTO URL (RFC6068) for the party",
+          "format": "email"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the party"
+        },
+        "did": {
+          "type": "string",
+          "description": "Decentralized Identifier (DID) URI for the party"
         },
         "validation": {
-          "type": "string"
+          "type": "string",
+          "description": "Label or token identifying the method of identity validation used"
         },
         "gmlpos": {
-          "type": "string"
+          "type": "string",
+          "description": "Geographic location in GML pos format (latitude longitude)"
         },
         "civicaddress": {
-          "$ref": "#/$defs/civicaddress"
+          "$ref": "#/definitions/Civicaddress"
         },
         "uuid": {
           "type": "string",
+          "description": "Unique identifier for the participant",
           "format": "uuid"
         }
       }
     },
-    "civicaddress": {
+    "Civicaddress": {
       "type": "object",
+      "description": "Civic address information for a party's location",
       "properties": {
-        "country": { "type": "string" },
-        "a1": { "type": "string" },
-        "a2": { "type": "string" },
-        "a3": { "type": "string" },
-        "a4": { "type": "string" },
-        "a5": { "type": "string" },
-        "a6": { "type": "string" },
-        "prd": { "type": "string" },
-        "pod": { "type": "string" },
-        "sts": { "type": "string" },
-        "hno": { "type": "string" },
-        "hns": { "type": "string" },
-        "lmk": { "type": "string" },
-        "loc": { "type": "string" },
-        "flr": { "type": "string" },
-        "nam": { "type": "string" },
-        "pc": { "type": "string" }
+        "country": {"type": "string"},
+        "a1": {"type": "string", "description": "National subdivision (state/province)"},
+        "a2": {"type": "string", "description": "County/parish/district"},
+        "a3": {"type": "string", "description": "City/township"},
+        "a4": {"type": "string", "description": "City division/borough"},
+        "a5": {"type": "string", "description": "Neighborhood/block"},
+        "a6": {"type": "string", "description": "Street"},
+        "prd": {"type": "string", "description": "Leading street direction"},
+        "pod": {"type": "string", "description": "Trailing street suffix"},
+        "sts": {"type": "string", "description": "Street suffix"},
+        "hno": {"type": "string", "description": "House number"},
+        "hns": {"type": "string", "description": "House number suffix"},
+        "lmk": {"type": "string", "description": "Landmark"},
+        "loc": {"type": "string", "description": "Additional location info"},
+        "flr": {"type": "string", "description": "Floor"},
+        "nam": {"type": "string", "description": "Name/occupant"},
+        "pc": {"type": "string", "description": "Postal code"}
       }
     },
-    "dialog": {
+    "Dialog": {
       "type": "object",
+      "description": "Represents a segment of captured conversation",
+      "required": ["type", "start"],
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["recording", "text", "transfer", "incomplete"],
+          "description": "Type of dialog"
         },
         "start": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Start time of the dialog in RFC3339 format"
         },
         "duration": {
-          "type": "number",
-          "minimum": 0
+          "anyOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "number", "minimum": 0}
+          ],
+          "description": "Duration in seconds"
         },
         "parties": {
           "anyOf": [
-            { "type": "integer", "minimum": 0 },
+            {"type": "integer", "minimum": 0},
+            {"type": "array", "items": {"type": "integer", "minimum": 0}},
             {
               "type": "array",
               "items": {
-                "type": "integer",
-                "minimum": 0
+                "anyOf": [
+                  {"type": "integer", "minimum": 0},
+                  {"type": "array", "items": {"type": "integer", "minimum": 0}}
+                ]
               }
-            },
+            }
+          ],
+          "description": "Index/indices of parties in the parties array"
+        },
+        "originator": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Index of the originating party if first party is not the originator"
+        },
+        "mediatype": {
+          "type": "string",
+          "description": "Media type of the dialog content"
+        },
+        "filename": {
+          "type": "string",
+          "description": "Original filename of the dialog content"
+        },
+        "body": {
+          "type": "string",
+          "description": "Inline content of the dialog (for inline files)"
+        },
+        "encoding": {
+          "type": "string",
+          "enum": ["base64url", "json", "none"],
+          "description": "Encoding type for inline content"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "HTTPS URL for externally referenced content"
+        },
+        "content_hash": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ],
+          "description": "Hash(es) of external content"
+        },
+        "disposition": {
+          "type": "string",
+          "enum": ["no-answer", "congestion", "failed", "busy", "hung-up", "voicemail-no-message"],
+          "description": "Reason for incomplete dialog (required for incomplete type)"
+        },
+        "session_id": {
+          "oneOf": [
+            {"$ref": "#/definitions/SessionId"},
+            {"type": "array", "items": {"$ref": "#/definitions/SessionId"}},
             {
               "type": "array",
               "items": {
                 "oneOf": [
-                  { "type": "integer", "minimum": 0 },
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "integer",
-                      "minimum": 0
-                    }
-                  }
+                  {"$ref": "#/definitions/SessionId"},
+                  {"type": "array", "items": {"$ref": "#/definitions/SessionId"}}
                 ]
               }
             }
-          ]
-        },
-        "originator": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "mediatype": {
-          "type": "string"
-        },
-        "filename": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "encoding": {
-          "type": "string",
-          "enum": ["base64url", "json", "none"]
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_hash": {
-          "$ref": "#/$defs/content_hash_value"
-        },
-        "disposition": {
-          "type": "string",
-          "enum": [
-            "no-answer",
-            "congestion",
-            "failed",
-            "busy",
-            "hung-up",
-            "voicemail-no-message"
-          ]
+          ],
+          "description": "Session ID(s) for the dialog"
         },
         "party_history": {
           "type": "array",
-          "items": {
-            "$ref": "#/$defs/party_history"
-          }
-        },
-        "session_id": {
-          "oneOf": [
-            { "$ref": "#/$defs/session_id" },
-            {
-              "type": "array",
-              "items": { "$ref": "#/$defs/session_id" }
-            }
-          ]
+          "items": {"$ref": "#/definitions/PartyHistory"},
+          "description": "History of party join/drop/hold/mute events"
         },
         "transferee": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "Party index of the transferee (for transfer type)"
         },
         "transferor": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "Party index of the transferor (for transfer type)"
         },
         "transfer_target": {
-          "$ref": "#/$defs/int_or_array"
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "array", "items": {"type": "integer", "minimum": 0}}
+          ],
+          "description": "Party index/indices of the transfer target (for transfer type)"
         },
         "original": {
-          "$ref": "#/$defs/int_or_array"
+          "oneOf": [
+            {"type": "integer", "minimum": -1},
+            {"type": "array", "items": {"type": "integer", "minimum": -1}}
+          ],
+          "description": "Dialog index/indices of original conversation (for transfer type)"
         },
         "consultation": {
-          "$ref": "#/$defs/int_or_array"
+          "oneOf": [
+            {"type": "integer", "minimum": -1},
+            {"type": "array", "items": {"type": "integer", "minimum": -1}}
+          ],
+          "description": "Dialog index/indices of consultation (for transfer type)"
         },
         "target_dialog": {
-          "$ref": "#/$defs/int_or_array"
+          "oneOf": [
+            {"type": "integer", "minimum": -1},
+            {"type": "array", "items": {"type": "integer", "minimum": -1}}
+          ],
+          "description": "Dialog index/indices of target dialog (for transfer type)"
         },
         "application": {
-          "type": "string"
+          "type": "string",
+          "description": "Application, communication channel or context of the conversation"
         },
         "message_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Unique message identifier from the messaging system"
         }
-      },
-      "required": [
-        "type",
-        "start"
-      ]
+      }
     },
-    "party_history": {
+    "SessionId": {
       "type": "object",
+      "description": "Session identifier with local and remote UUIDs",
+      "required": ["local", "remote"],
+      "properties": {
+        "local": {
+          "type": "string",
+          "description": "Local UUID for the session"
+        },
+        "remote": {
+          "type": "string",
+          "description": "Remote UUID for the session"
+        }
+      }
+    },
+    "PartyHistory": {
+      "type": "object",
+      "description": "Records party events during the dialog",
+      "required": ["party", "time", "event"],
       "properties": {
         "party": {
           "type": "integer",
-          "minimum": 0
-        },
-        "event": {
-          "type": "string",
-          "enum": ["join", "drop", "hold", "unhold", "mute", "unmute", "keydown", "keyup"]
+          "minimum": 0,
+          "description": "Index of the party"
         },
         "time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the event in RFC3339 format"
+        },
+        "event": {
+          "type": "string",
+          "enum": ["join", "drop", "hold", "unhold", "mute", "unmute", "keydown", "keyup"],
+          "description": "Type of event"
         },
         "button": {
           "type": "string",
-          "description": "Required for keydown/keyup events"
+          "description": "DTMF digit, character or string (required for keydown/keyup events)"
         }
-      },
-      "required": [
-        "party",
-        "event",
-        "time"
-      ]
+      }
     },
-    "session_id": {
+    "Attachment": {
       "type": "object",
+      "description": "Represents an ancillary document related to the conversation",
+      "required": ["start", "party", "dialog"],
       "properties": {
-        "local": { "type": "string" },
-        "remote": { "type": "string" }
-      },
-      "required": ["local", "remote"]
-    },
-    "analysis": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "dialog": {
-          "oneOf": [
-            { "type": "integer", "minimum": 0 },
-            { "type": "array", "items": {"type": "integer", "minimum": 0} }
-          ]
-        },
-        "mediatype": {
-          "type": "string"
-        },
-        "filename": {
-          "type": "string"
-        },
-        "vendor": {
-          "type": "string"
-        },
-        "product": {
-          "type": "string"
-        },
-        "schema": {
-          "type": ["string", "object"]
-        },
-        "body": {
-          "type": ["string", "object", "array"]
-        },
-        "encoding": {
+        "purpose": {
           "type": "string",
-          "enum": ["base64url", "json", "none"]
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_hash": {
-          "$ref": "#/$defs/content_hash_value"
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "attachment": {
-      "type": "object",
-      "properties": {
-        "body": {
-          "type": "string"
-        },
-        "encoding": {
-          "type": "string",
-          "enum": ["base64url", "json", "none"]
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_hash": {
-          "$ref": "#/$defs/content_hash_value"
-        },
-        "dialog": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "party": {
-          "type": "integer",
-          "minimum": 0
+          "description": "text description of what the attachment is for"
         },
         "start": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time the attachment was sent/exchanged in RFC3339 format"
+        },
+        "party": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Index of the party that contributed the attachment"
+        },
+        "dialog": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Index of the dialog this attachment is part of"
         },
         "mediatype": {
-          "type": "string"
+          "type": "string",
+          "description": "Media type of the attachment"
         },
         "filename": {
-          "type": "string"
+          "type": "string",
+          "description": "Original filename of the attachment"
         },
-        "purpose": {
-          "type": "string"
+        "body": {
+          "type": "string",
+          "description": "Inline content of the attachment (for inline files)"
+        },
+        "encoding": {
+          "type": "string",
+          "enum": ["base64url", "json", "none"],
+          "description": "Encoding type for inline content"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "HTTPS URL for externally referenced attachment"
+        },
+        "content_hash": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ],
+          "description": "Hash(es) of external content"
         }
-      },
-      "required": [
-        "start",
-        "party"
-      ]
+      }
+    },
+    "Analysis": {
+      "type": "object",
+      "description": "Represents analysis performed on the conversational data",
+      "required": ["type", "vendor"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Semantic type of analysis (e.g., report, sentiment, summary, transcript, translation, tts)"
+        },
+        "dialog": {
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "array", "items": {"type": "integer", "minimum": 0}}
+          ],
+          "description": "Index/indices of dialog objects this analysis is based on"
+        },
+        "mediatype": {
+          "type": "string",
+          "description": "Media type of the analysis file"
+        },
+        "filename": {
+          "type": "string",
+          "description": "Original filename of the analysis data"
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Vendor or product name that generated the analysis"
+        },
+        "product": {
+          "type": "string",
+          "description": "Product name to differentiate from other vendor products"
+        },
+        "schema": {
+          "type": "string",
+          "description": "Token or label for the data format/schema of the analysis"
+        },
+        "body": {
+          "type": "string",
+          "description": "Inline content of the analysis (for inline files)"
+        },
+        "encoding": {
+          "type": "string",
+          "enum": ["base64url", "json", "none"],
+          "description": "Encoding type for inline content"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "HTTPS URL for externally referenced analysis"
+        },
+        "content_hash": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ],
+          "description": "Hash(es) of external content"
+        }
+      }
     }
   }
 }

--- a/pkg/vcon/vcon.go
+++ b/pkg/vcon/vcon.go
@@ -97,10 +97,10 @@ type Analysis struct {
 	Dialog      interface{}     `json:"dialog,omitempty"`
 	MediaType   string          `json:"mediatype,omitempty"`
 	Filename    string          `json:"filename,omitempty"`
-	Vendor      string          `json:"vendor,omitempty"`
+	Vendor      string          `json:"vendor"`
 	Product     string          `json:"product,omitempty"`
-	Schema      interface{}     `json:"schema,omitempty"`
-	Body        interface{}     `json:"body,omitempty"`
+	Schema      string          `json:"schema,omitempty"`
+	Body        string          `json:"body,omitempty"`
 	Encoding    string          `json:"encoding,omitempty"`
 	URL         string          `json:"url,omitempty"`
 	ContentHash ContentHashList `json:"content_hash,omitempty"`
@@ -189,7 +189,24 @@ func New(domain string, propertyHandling ...string) *VCon {
 
 func validateAgainstSchema(rawMap map[string]interface{}) error {
 	compiler := jsonschema.NewCompiler()
-	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.DefaultDraft(jsonschema.Draft7)
+	// Override the default email format validator to also accept mailto: URIs,
+	// since the vCon spec defines the mailto field as a MAILTO URL (RFC 6068).
+	compiler.RegisterFormat(&jsonschema.Format{
+		Name: "email",
+		Validate: func(v interface{}) error {
+			s, ok := v.(string)
+			if !ok {
+				return nil
+			}
+			s = strings.TrimPrefix(s, "mailto:")
+			parts := strings.SplitN(s, "@", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				return fmt.Errorf("invalid email: %s", v)
+			}
+			return nil
+		},
+	})
 
 	var schemaData interface{}
 	if err := json.Unmarshal(vconSchema, &schemaData); err != nil {
@@ -339,11 +356,19 @@ func migrateV003ToV040(m map[string]interface{}) {
 	migrateSliceItems(m, "attachments", func(am map[string]interface{}) {
 		delete(am, "meta")
 		migrateEncodingAndHash(am)
+		// "dialog" is now required by the IETF schema
+		if _, ok := am["dialog"]; !ok {
+			am["dialog"] = float64(0)
+		}
 	})
 
 	migrateSliceItems(m, "analysis", func(am map[string]interface{}) {
 		delete(am, "meta")
 		migrateEncodingAndHash(am)
+		// "vendor" is now required by the IETF schema
+		if _, ok := am["vendor"]; !ok || am["vendor"] == "" {
+			am["vendor"] = "unknown"
+		}
 	})
 }
 
@@ -646,12 +671,27 @@ func (v *VCon) validateDialogs() []string {
 func (v *VCon) validateAnalysis() []string {
 	var errs []string
 	for i, analysis := range v.Analysis {
+		if analysis.Vendor == "" {
+			errs = append(errs, fmt.Sprintf("analysis at index %d missing required field: vendor", i))
+		}
 		if dialogs, ok := analysis.Dialog.([]int); ok {
 			for _, dialogIdx := range dialogs {
 				if dialogIdx < 0 || dialogIdx >= len(v.Dialog) {
 					errs = append(errs, fmt.Sprintf("analysis at index %d references invalid dialog index: %d", i, dialogIdx))
 				}
 			}
+		}
+	}
+	return errs
+}
+
+func (v *VCon) validateAttachments() []string {
+	var errs []string
+	for i, att := range v.Attachments {
+		if att.DialogIdx == nil {
+			errs = append(errs, fmt.Sprintf("attachment at index %d missing required field: dialog", i))
+		} else if *att.DialogIdx < 0 || *att.DialogIdx >= len(v.Dialog) {
+			errs = append(errs, fmt.Sprintf("attachment at index %d references invalid dialog index: %d", i, *att.DialogIdx))
 		}
 	}
 	return errs
@@ -664,6 +704,7 @@ func (v *VCon) allValidationErrors() []string {
 	errs = append(errs, v.validateCriticalExtensions()...)
 	errs = append(errs, v.validateDialogs()...)
 	errs = append(errs, v.validateAnalysis()...)
+	errs = append(errs, v.validateAttachments()...)
 	return errs
 }
 

--- a/pkg/vcon/vcon_extended_test.go
+++ b/pkg/vcon/vcon_extended_test.go
@@ -458,17 +458,23 @@ func TestV003Migration(t *testing.T) {
 	// CC extension fields should be removed from dialog
 	// (campaign, interaction_type, interaction_id, skill are no longer on Dialog struct)
 
-	// Analysis encoding should be migrated
+	// Analysis encoding should be migrated, vendor should be set
 	if len(v.Analysis) != 1 {
 		t.Fatalf("expected 1 analysis, got %d", len(v.Analysis))
 	}
+	if v.Analysis[0].Vendor != "unknown" {
+		t.Errorf("expected analysis vendor 'unknown' after migration, got %s", v.Analysis[0].Vendor)
+	}
 
-	// Attachments encoding should be migrated
+	// Attachments encoding should be migrated, dialog should be set
 	if len(v.Attachments) != 1 {
 		t.Fatalf("expected 1 attachment, got %d", len(v.Attachments))
 	}
 	if v.Attachments[0].Encoding != "base64url" {
 		t.Errorf("expected attachment encoding base64url after migration, got %s", v.Attachments[0].Encoding)
+	}
+	if v.Attachments[0].DialogIdx == nil || *v.Attachments[0].DialogIdx != 0 {
+		t.Errorf("expected attachment dialog index 0 after migration, got %v", v.Attachments[0].DialogIdx)
 	}
 }
 
@@ -489,5 +495,57 @@ func TestV003MigrationFromFile(t *testing.T) {
 		if d.Encoding == "base64" {
 			t.Errorf("dialog[%d] encoding should not be 'base64' after migration", i)
 		}
+	}
+}
+
+func TestAnalysisVendorRequired(t *testing.T) {
+	// Analysis missing "vendor" should fail schema validation via BuildFromJSON
+	jsonStr := `{
+		"vcon": "0.4.0",
+		"uuid": "550e8400-e29b-41d4-a716-446655440000",
+		"created_at": "2023-01-15T10:30:00Z",
+		"parties": [{"name": "Alice"}],
+		"analysis": [
+			{
+				"type": "sentiment",
+				"body": "positive",
+				"encoding": "none"
+			}
+		]
+	}`
+	_, err := BuildFromJSON(jsonStr)
+	if err == nil {
+		t.Error("expected error for analysis missing required 'vendor' field")
+	}
+}
+
+func TestDialogTypeEnumSchemaValidation(t *testing.T) {
+	// Dialog with invalid type should fail schema validation
+	invalidJSON := `{
+		"vcon": "0.4.0",
+		"uuid": "550e8400-e29b-41d4-a716-446655440000",
+		"created_at": "2023-01-15T10:30:00Z",
+		"parties": [{"name": "Alice"}],
+		"dialog": [{"type": "email", "start": "2023-01-15T10:30:00Z"}]
+	}`
+	_, err := BuildFromJSON(invalidJSON)
+	if err == nil {
+		t.Error("expected error for dialog with invalid type 'email'")
+	}
+
+	// Dialog with valid type should pass
+	validJSON := `{
+		"vcon": "0.4.0",
+		"uuid": "550e8400-e29b-41d4-a716-446655440000",
+		"created_at": "2023-01-15T10:30:00Z",
+		"parties": [{"name": "Alice"}],
+		"dialog": [{"type": "recording", "start": "2023-01-15T10:30:00Z"}]
+	}`
+	v, err := BuildFromJSON(validJSON)
+	if err != nil {
+		t.Errorf("expected no error for valid dialog type, got: %v", err)
+	}
+	if v != nil && len(v.Dialog) > 0 && v.Dialog[0].Type != "recording" {
+		t.Errorf("expected dialog type 'recording', got '%s'", v.Dialog[0].Type)
 	}
 }


### PR DESCRIPTION
…cial IETF Working Group schema from `ietf-wg-vcon/draft-ietf-vcon-vcon-core` (Draft-07).

- **`Attachment.DialogIdx`**: `int` → `*int` (now required by schema). Use `IntPtr(n)` helper.
- **`Analysis.Vendor`**: removed `omitempty` (now required by schema).
- **`Analysis.Schema`** and **`Analysis.Body`**: `interface{}` → `string`.
- **Dialog `type`**: restricted to enum `recording`, `text`, `transfer`, `incomplete`. The `email` and `conference` types are no longer valid.

- Schema compiler switched from `Draft2020` to `Draft7`.
- Custom email format validator accepts both bare emails and `mailto:` URIs.
- v0.0.3 migration now adds `dialog: 0` to attachments and `vendor: "unknown"` to analysis missing those fields.
- `convert email` CLI command now uses `type: "text"` with `application: "email"`.
- Added `validateAttachments()` to catch nil `DialogIdx` and invalid dialog index references.
- New tests: `TestAttachmentDialogRequired`, `TestAnalysisVendorRequired`, `TestDialogTypeEnumSchemaValidation`.